### PR TITLE
Update Makefile

### DIFF
--- a/src/cpp/Makefile
+++ b/src/cpp/Makefile
@@ -11,14 +11,15 @@
 #  -----------------------------------------------------------------------------------------------------------------------
 
 # Define the compiler
+PYTHON=python
 CC := g++
 
 # Read Tensorflow paths
-TF_INC := $(shell python -c 'import tensorflow as tf; print(tf.sysconfig.get_include())')
-TF_LIB := $(shell python -c 'import tensorflow as tf; print(tf.sysconfig.get_lib())')
+TF_INC := $(shell ${PYTHON} -c 'import tensorflow as tf; print(tf.sysconfig.get_include())')
+TF_LIB := $(shell ${PYTHON} -c 'import tensorflow as tf; print(tf.sysconfig.get_lib())')
 
 # Is the Tensorflow version >= 1.4?
-TF_VERSION_GTE_1_4 := $(shell expr `python -c 'import tensorflow as tf; print(tf.__version__)' | cut -f1,2 -d.` \>= 1.4)
+TF_VERSION_GTE_1_4 := $(shell expr `${PYTHON} -c 'import tensorflow as tf; print(tf.__version__)' | cut -f1,2 -d.` \>= 1.4)
 
 # Flags required for all cases
 CFLAGS := -std=c++11 -D_GLIBCXX_USE_CXX11_ABI=0 -shared -fPIC -I$(TF_INC) -O2 


### PR DESCRIPTION
make the reference to Python more flexible. i.e., python3 users can do the following and not need to mess with aliasing or path nonsense:

```shell
make PYTHON=python3
```